### PR TITLE
Get all tags and lists

### DIFF
--- a/src/Services/ActiveCampaignService.php
+++ b/src/Services/ActiveCampaignService.php
@@ -62,7 +62,7 @@ class ActiveCampaignService
 
     public function getLists(): ?array
     {
-        $response = $this->client()->get('lists');
+        $response = $this->client()->get('lists', ['limit' => -1]);
 
         return $this->handleResponse($response, 'Failed to get lists');
     }
@@ -76,7 +76,7 @@ class ActiveCampaignService
 
     public function listTags(): ?array
     {
-        $response = $this->client()->get('tags');
+        $response = $this->client()->get('tags', ['limit' => -1]);
 
         return $this->handleResponse($response, 'Failed to list tags');
     }


### PR DESCRIPTION
Currently, only 20 lists and tags are being retrieved, so some are missing when you have more than 20. This change ensures that all of them are retrieved.