### PR TITLE
Convert array field values to string

### DIFF
--- a/src/Listeners/AddFromSubmission.php
+++ b/src/Listeners/AddFromSubmission.php
@@ -104,11 +104,19 @@ class AddFromSubmission
         })->filter()->all();
 
         $customData = $customFields->map(function ($item) {
+            $fieldValue = $this->data->get($item['statamic_field']);
+
+            if (is_array($fieldValue)) {
+                $fieldValue = implode(', ', array_filter($fieldValue, fn($value) => $value !== null && $value !== ''));
+            } elseif ($fieldValue === null) {
+                $fieldValue = '';
+            }
+
             return [
                 'field' => $item['activecampaign_field'],
-                'value' => $this->data->get($item['statamic_field'])
+                'value' => (string) $fieldValue
             ];
-        })->filter()->values()->all();
+        })->filter(fn($item) => $item['value'] !== '')->values()->all();
 
         return array_merge($standardData, ['fieldValues' => $customData]);
     }


### PR DESCRIPTION
So at the moment when there's a multi checkbox field in a form, the values of this field don't correctly get send to ActiveCampaign as arrays aren't being parsed.

<img width="468" height="356" alt="Screenshot 2025-07-14 at 13 58 06" src="https://github.com/user-attachments/assets/63e17d3e-5519-4cba-acb2-f4914e871c83" />

This change would implode array values to a comma separated string:

<img width="609" height="320" alt="Screenshot 2025-07-14 at 14 02 30" src="https://github.com/user-attachments/assets/1ae793d1-51a3-402c-a4da-8006ffc0394d" />


